### PR TITLE
Add `Framework :: napari`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,7 @@ setup(
         'Development Status :: 4 - Beta',
         'Intended Audience :: Developers',
         'Topic :: Software Development :: Testing',
+        'Framework :: napari',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.6',


### PR DESCRIPTION
This PR adds `Framework :: napari` to the setup config so that the next release will appear on https://www.napari-hub.org/!