### PR TITLE
Load tomograms in permissive read mode

### DIFF
--- a/napari_mrcfile_reader/mrcfile_reader.py
+++ b/napari_mrcfile_reader/mrcfile_reader.py
@@ -68,7 +68,7 @@ def reader_function(path):
     # handle both a string and a list of strings
     paths = [path] if isinstance(path, str) else path
     # load all files into array
-    arrays = [mrcfile.open(_path).data for _path in paths]
+    arrays = [mrcfile.open(_path, permissive=True).data for _path in paths]
     # stack arrays into single array
     data = np.squeeze(np.stack(arrays))
 


### PR DESCRIPTION
Hi, first of all thanks for all the work!

I'd like to propose loading tomograms in a permissive read mode, since not all frameworks write the correct .mrc file headers.

Shouldn't create any problems with backward compatibility, but will allow reading more files.

Ilja