### PR TITLE
Implemented support for complex valued mrcfiles

### DIFF
--- a/napari_mrcfile_reader/mrcfile_reader.py
+++ b/napari_mrcfile_reader/mrcfile_reader.py
@@ -67,14 +67,26 @@ def reader_function(path):
     """
     # handle both a string and a list of strings
     paths = [path] if isinstance(path, str) else path
-    # load all files into array
-    arrays = [mrcfile.open(_path, permissive=True).data for _path in paths]
-    # stack arrays into single array
-    data = np.squeeze(np.stack(arrays))
 
     # optional kwargs for the corresponding viewer.add_* method
     # https://napari.org/docs/api/napari.components.html#module-napari.components.add_layers_mixin
     add_kwargs = {}
 
-    layer_type = "image"  # optional, default is "image"
-    return [(data, add_kwargs, layer_type)]
+    # optional, default is "image"
+    layer_type = "image"
+
+    # load all files into array
+    layers = []
+    for _path in paths:
+
+        # Read mrcfile as a memory mapped file
+        data = mrcfile.mmap(_path, permissive=True).data
+
+        # Append two layers if the data type is complex
+        if data.dtype in [np.complex64, np.complex128]:
+            layers.append((np.abs(data), {"name": "amplitude"}, layer_type))
+            layers.append((np.angle(data), {"name": "phase"}, layer_type))
+        else:
+            layers.append((data, add_kwargs, layer_type))
+
+    return layers

--- a/napari_mrcfile_reader/mrcfile_reader.py
+++ b/napari_mrcfile_reader/mrcfile_reader.py
@@ -76,7 +76,7 @@ def reader_function(path):
     layer_type = "image"
 
     # load all files into array
-    layers = []
+    layer_data = []
     for _path in paths:
 
         # Read mrcfile as a memory mapped file
@@ -84,9 +84,9 @@ def reader_function(path):
 
         # Append two layers if the data type is complex
         if data.dtype in [np.complex64, np.complex128]:
-            layers.append((np.abs(data), {"name": "amplitude"}, layer_type))
-            layers.append((np.angle(data), {"name": "phase"}, layer_type))
+            layer_data.append((np.abs(data), {"name": "amplitude"}, layer_type))
+            layer_data.append((np.angle(data), {"name": "phase"}, layer_type))
         else:
-            layers.append((data, add_kwargs, layer_type))
+            layer_data.append((data, add_kwargs, layer_type))
 
-    return layers
+    return layer_data


### PR DESCRIPTION
Hi Alister

I have made a change to allow complex valued mrcfiles to be read by the mrcfile plugin. The complex array is read into two layers: amplitude and phase. I considered this to be more useful than displaying the real and imaginary components. Additionally, I changed to reading the mrcfile in as a memory mapped file. I believe that this may offer better performance when reading in large files containing many images.

Best wishes
James 