### PR TITLE
Add simple montage support

### DIFF
--- a/src/napari_mrcfile_reader/mdoc.py
+++ b/src/napari_mrcfile_reader/mdoc.py
@@ -1,0 +1,19 @@
+from pathlib import Path
+
+
+class MDOC:
+    def __init__(self, path: str):
+        self.path = Path(path)
+        self.montage = False
+        self.piece_coords = []
+        self.aligned_piece_coords = []
+
+        if self.path.is_file():
+            with open(self.path) as file:
+                for line in file:
+                    if line.startswith('Montage = '):
+                        self.montage = bool(line.split()[-1])
+                    elif line.startswith('PieceCoordinates = '):
+                        self.piece_coords.append(tuple(map(int, line.split()[-3:])))
+                    elif line.startswith('AlignedPieceCoords = '):
+                        self.aligned_piece_coords.append(tuple(map(int, line.split()[-3:])))


### PR DESCRIPTION
Hello,

I thought it would be useful to add some support for montages. Piece coordinates are read from an MDOC file if there is one and all pieces are just merged into one big array. If there is no MDOC file it falls back to the default behaviour. If you're interested, I could also add support for reading the piece coordinates from the extended header.

I realize montage support might be out of scope for this package and you would rather like to read the MRC data into napari "as is". However, in my lab we have quite some use for montage support because I also wrote a little napari plugin to read SerialEM navigator files, and with proper montage support it gets very easy to find the spots where one acquired tilt series.

Just do add one more thing: as it is now I ran barely any tests, so should you decide to merge this please just wait a little bit to make sure I didn't accidentally break anything.